### PR TITLE
chore: configure environment variables with Zod validation

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,9 +1,9 @@
-# Database connection string
+# Required — PostgreSQL connection string
 DATABASE_URL="postgresql://USER:PASSWORD@HOST:PORT/DATABASE?schema=public"
 
-# TMDB API Key (for movie metadata - needed in M3)
-TMDB_API_KEY=""
+# Optional — TMDB API key for movie metadata (needed in M3)
+TMDB_API_KEY=
 
-# NextAuth (for authentication - needed in M5)
-NEXTAUTH_SECRET=""
+# Optional — NextAuth.js authentication (needed in M5)
+NEXTAUTH_SECRET=
 NEXTAUTH_URL="http://localhost:3000"

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,8 @@
         "@prisma/client": "^7.4.2",
         "next": "16.1.6",
         "react": "19.2.3",
-        "react-dom": "19.2.3"
+        "react-dom": "19.2.3",
+        "zod": "^4.3.6"
       },
       "devDependencies": {
         "@tailwindcss/postcss": "^4",
@@ -3892,9 +3893,9 @@
       }
     },
     "node_modules/flatted": {
-      "version": "3.3.4",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.4.tgz",
-      "integrity": "sha512-3+mMldrTAPdta5kjX2G2J7iX4zxtnwpdA8Tr2ZSjkyPSanvbZAcy6flmtnXbEybHrDcU9641lxrMfFuUxVz9vA==",
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.1.tgz",
+      "integrity": "sha512-IxfVbRFVlV8V/yRaGzk0UVIcsKKHMSfYw66T/u4nTwlWteQePsxe//LjudR1AMX4tZW3WFCh3Zqa/sjlqpbURQ==",
       "dev": true,
       "license": "ISC"
     },
@@ -7040,7 +7041,6 @@
       "version": "4.3.6",
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
-      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "@prisma/client": "^7.4.2",
     "next": "16.1.6",
     "react": "19.2.3",
-    "react-dom": "19.2.3"
+    "react-dom": "19.2.3",
+    "zod": "^4.3.6"
   },
   "devDependencies": {
     "@tailwindcss/postcss": "^4",

--- a/src/lib/env.ts
+++ b/src/lib/env.ts
@@ -1,0 +1,17 @@
+import { z } from 'zod';
+
+const envSchema =    z.object({
+    DATABASE_URL:    z.string(),
+    TMDB_API_KEY:    z.string().optional(),
+    NEXTAUTH_SECRET: z.string().optional(),
+    NEXTAUTH_URL:    z.string().url().optional()
+});
+
+const parsed = envSchema.safeParse(process.env);
+
+if (!parsed.success) {
+    console.error('Invalid environment variables: ', parsed.error.flatten());
+    throw new Error('Missing or invalid environment variables');
+}
+
+export const env = parsed.data;


### PR DESCRIPTION
Closes #7 — Adds Zod-based environment variable validation that fails fast on missing required variables. DATABASE_URL is required; TMDB and NextAuth variables are optional until their respective milestones.